### PR TITLE
added where::asLiteral

### DIFF
--- a/src/Builder/Syntax/WhereWriter.php
+++ b/src/Builder/Syntax/WhereWriter.php
@@ -196,6 +196,10 @@ class WhereWriter extends AbstractBaseWriter
             $comparisons,
             function (&$comparison) {
 
+                if (!is_array($comparison)) {
+                    return;
+                }
+
                 $str = $this->writeWherePartialCondition($comparison['subject']);
                 $str .= $this->writer->writeConjunction($comparison['conjunction']);
                 $str .= $this->writeWherePartialCondition($comparison['target']);

--- a/src/Syntax/Where.php
+++ b/src/Syntax/Where.php
@@ -383,6 +383,18 @@ class Where
     }
 
     /**
+     * @param string $literal
+     *
+     * @return $this
+     */
+    public function asLiteral($literal)
+    {
+        $this->comparisons[] = $literal;
+
+        return $this;
+    }
+
+    /**
      * @param string[] $columns
      * @param mixed[]  $values
      *

--- a/tests/Builder/Syntax/WhereWriterTest.php
+++ b/tests/Builder/Syntax/WhereWriterTest.php
@@ -520,4 +520,23 @@ class WhereWriterTest extends \PHPUnit_Framework_TestCase
         $expected = array(':v1' => 'Nil', ':v2' => 1);
         $this->assertEquals($expected, $this->writer->getValues());
     }
+
+    /**
+     * @test
+     */
+    public function itShouldAllowWhereConditionAsLiteral()
+    {
+        $this->query
+            ->setTable('user')
+            ->where()
+            ->asLiteral("(username is not null and status=:status)")
+            ->notEquals('name', '%N%');
+
+        $expected = "SELECT user.* FROM user WHERE (username is not null and status=:status) AND (user.name <> :v1)";
+
+        $this->assertSame($expected, $this->writer->write($this->query));
+
+        $expected = array(':v1' => '%N%');
+        $this->assertEquals($expected, $this->writer->getValues());
+    }
 }

--- a/tests/Syntax/WhereTest.php
+++ b/tests/Syntax/WhereTest.php
@@ -407,4 +407,13 @@ class WhereTest extends \PHPUnit_Framework_TestCase
 
         $this->assertEquals(array($select1), $result);
     }
+
+    /**
+     * @test
+     */
+    public function itShouldReturnLiterals()
+    {
+        $result = $this->where->asLiteral("(username is not null and status=:status)")->getComparisons();
+        $this->assertSame("(username is not null and status=:status)", $result[0]);
+    }
 }


### PR DESCRIPTION
Added method to add more 'free-form' where conditionals:

    $this->query
        ->setTable('user')
        ->where()
        ->asLiteral("(username is not null and status=:status)")
        ->notEquals('name', '%N%');

which will result in the query

    SELECT user.* FROM user WHERE (username is not null and status=:status) AND (user.name <> :v1)